### PR TITLE
Implement templates and e-mail sending to users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project",
- "rand",
+ "rand 0.7.3",
  "regex",
  "serde",
  "serde_json",
@@ -308,6 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
 name = "async-channel"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +406,12 @@ checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -421,7 +433,7 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding",
- "rand",
+ "rand 0.7.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -439,6 +451,25 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+dependencies = [
+ "byteorder",
+ "safemem",
+]
+
+[[package]]
+name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -592,6 +623,15 @@ dependencies = [
 
 [[package]]
 name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "cloudabi"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
@@ -674,7 +714,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cfg-if",
  "lazy_static",
 ]
@@ -726,6 +766,85 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
+name = "email"
+version = "0.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91549a51bb0241165f13d57fc4c72cef063b4088fb078b019ecbf464a45f22e4"
+dependencies = [
+ "base64 0.9.3",
+ "chrono",
+ "encoding",
+ "lazy_static",
+ "rand 0.4.6",
+ "time",
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "encoding_rs"
@@ -783,6 +902,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +957,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1029,8 +1163,11 @@ dependencies = [
  "git2",
  "gitarena-proc-macro",
  "lazy_static",
+ "lettre 0.10.0-alpha.2",
+ "lettre_email",
  "log",
- "rand",
+ "rand 0.7.3",
+ "regex",
  "reqwest",
  "rust-argon2",
  "serde",
@@ -1080,7 +1217,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -1193,6 +1330,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperx"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eae1ec4abdc4530fb001ebf585fd14e52ed17f0aacd3e13de497b71ed451750"
+dependencies = [
+ "base64 0.12.3",
+ "bytes",
+ "http",
+ "httparse",
+ "language-tags",
+ "log",
+ "mime",
+ "percent-encoding",
+ "time",
+ "unicase",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,7 +1364,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "hashbrown",
 ]
 
@@ -1300,6 +1455,71 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lettre"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf43f3202a879fbdab4ecafec3349b0139f81d31c626246d53bcbb546253ffaa"
+dependencies = [
+ "fast_chemail",
+ "log",
+]
+
+[[package]]
+name = "lettre"
+version = "0.10.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ef0e6a22631e37078148cff6ce1ef92984bdc2fbd2cb2cc804836db8196cc57"
+dependencies = [
+ "async-trait",
+ "base64 0.12.3",
+ "futures-io",
+ "futures-util",
+ "hostname",
+ "hyperx",
+ "idna",
+ "mime",
+ "native-tls",
+ "nom",
+ "once_cell",
+ "quoted_printable",
+ "r2d2",
+ "rand 0.7.3",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-native-tls",
+ "uuid 0.8.1",
+]
+
+[[package]]
+name = "lettre_email"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd02480f8dcf48798e62113974d6ccca2129a51d241fa20f1ea349c8a42559d5"
+dependencies = [
+ "base64 0.10.1",
+ "email",
+ "lettre 0.9.3",
+ "mime",
+ "time",
+ "uuid 0.7.4",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1469,10 +1689,22 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1496,6 +1728,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1528,12 +1770,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
@@ -1543,7 +1796,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -1600,7 +1853,7 @@ version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cc",
  "libc",
  "pkg-config",
@@ -1631,7 +1884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.1.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -1726,6 +1979,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b080c5db639b292ac79cbd34be0cfc5d36694768d8341109634d90b86930e2"
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,9 +2035,19 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1745,8 +2057,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1759,11 +2086,82 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi 0.0.3",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1870,6 +2268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +2281,15 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -2102,7 +2515,7 @@ dependencies = [
  "md-5",
  "memchr",
  "percent-encoding",
- "rand",
+ "rand 0.7.3",
  "sha-1",
  "sha2",
  "sqlformat",
@@ -2126,6 +2539,12 @@ dependencies = [
  "syn",
  "url",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -2164,7 +2583,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2238,11 +2657,22 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "mio-named-pipes",
  "mio-uds",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2340,7 +2770,7 @@ dependencies = [
  "idna",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.7.3",
  "smallvec",
  "socket2",
  "tokio",
@@ -2384,7 +2814,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2429,10 +2859,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
+dependencies = [
+ "rand 0.6.5",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ fern = "0.6.0"
 git2 = "0.13.8"
 gitarena-proc-macro = { version = "0.0.1", path = "gitarena-proc-macro" }
 lazy_static = "1.4.0"
+lettre = { version = "0.10.0-alpha.2", features = ["smtp-transport", "tokio02", "tokio02-native-tls"] }
+lettre_email = "0.9.4"
 log = "0.4.11"
 rand = "0.7.3"
+regex = "1.3.9"
 reqwest = { version = "0.10.7", features = ["json"] }
 rust-argon2 = { version = "0.8.2", features = ["crossbeam-utils"] }
 serde = { version = "1.0.114", features = ["derive"] }

--- a/config.toml
+++ b/config.toml
@@ -2,5 +2,15 @@
 
 bind = "localhost:8080"
 database = "postgresql://root@localhost/gitarena?sslmode=require"
-hcaptcha_site_key = ""
-hcaptcha_secret = ""
+
+[hcaptcha]
+site_key = ""
+secret = ""
+
+[smtp]
+server = "smtp.gitarena.com"
+port = 465
+tls = true
+email_address = "noreply@gitarena.com"
+username = "root"
+password = "hunter2"

--- a/schema.sql
+++ b/schema.sql
@@ -1,10 +1,11 @@
 create table users
 (
-	id serial not null,
-	username varchar(32) not null,
-	email varchar(128) not null,
-	password char(96) not null,
-	salt char(16) not null
+    id             serial                not null,
+    username       varchar(32)           not null,
+    email          varchar(128)          not null,
+    password       char(96)              not null,
+    salt           char(16)              not null,
+    email_verified boolean default false not null
 );
 
 create unique index users_username_uindex

--- a/src/captcha.rs
+++ b/src/captcha.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 
 pub(crate) async fn verify_captcha(token: &String) -> Result<bool> {
-    let api_key: &str = CONFIG.hcaptcha_secret.borrow();
+    let api_key: &str = CONFIG.hcaptcha.secret.borrow();
 
     let response: HCaptchaResponse = Client::new()
         .post("https://hcaptcha.com/siteverify")

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -1,0 +1,34 @@
+use anyhow::{Context, Result};
+use crate::CONFIG;
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncSmtpTransport, Message, Tokio02Connector, Tokio02Transport};
+use std::borrow::Borrow;
+
+pub(crate) async fn send_mail(message: Message) -> Result<()> {
+    let server: &str = CONFIG.smtp.server.borrow();
+    let username: &str = CONFIG.smtp.username.borrow();
+    let password: &str = CONFIG.smtp.password.borrow();
+    let raw_port: &i64 = CONFIG.smtp.port.borrow();
+    let tls: &bool = CONFIG.smtp.tls.borrow();
+    let port = *raw_port as u16;
+
+    let credentials = Credentials::new(username.to_owned(), password.to_owned());
+    let transporter;
+
+    if *tls {
+        transporter = AsyncSmtpTransport::<Tokio02Connector>::relay(server)
+            .context("Unable to create TLS connection.")?
+            .port(port)
+            .credentials(credentials)
+            .build();
+    } else {
+        transporter = AsyncSmtpTransport::<Tokio02Connector>::builder_dangerous(server)
+            .port(port)
+            .credentials(credentials)
+            .build();
+    }
+
+    transporter.send(message).await.context("Unable to send e-mail.")?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,9 @@ use std::path::Path;
 mod captcha;
 mod config;
 mod crypto;
+mod mail;
 mod routes;
+mod templates;
 mod user;
 
 type PgPoolConnection = PoolConnection<PgConnection>;

--- a/src/routes/user/user_create.rs
+++ b/src/routes/user/user_create.rs
@@ -1,11 +1,14 @@
 use actix_web::{HttpResponse, post, Responder, web};
 use crate::user::User;
-use crate::{captcha, PgPoolConnection};
+use crate::{captcha, PgPoolConnection, templates};
 use gitarena_proc_macro::generate_bail;
 use log::error;
+use log::info;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgQueryAs;
 use sqlx::{Connection, PgPool, Transaction};
+use std::collections::HashMap;
 
 generate_bail!(RegisterJsonResponse {
                    success: false,
@@ -15,11 +18,14 @@ generate_bail!(RegisterJsonResponse {
 
 #[post("/api/user")]
 pub(crate) async fn register(body: web::Json<RegisterJsonRequest>, db_pool: web::Data<PgPool>) -> impl Responder {
-    let connection = bail!(db_pool.acquire().await);
+    let connection: PgPoolConnection = bail!(db_pool.acquire().await);
     let mut transaction: Transaction<PgPoolConnection> = bail!(connection.begin().await);
 
-    let (exists,): (bool,) = bail!(sqlx::query_as("select exists(select 1 from users where username = $1);")
-        .bind(&body.username)
+    let username = validate_username(&body.username); // todo: check if empty
+    let lowered_username = username.to_lowercase();
+
+    let (exists,): (bool,) = bail!(sqlx::query_as("select exists(select 1 from users where lower(username) = $1);")
+        .bind(&lowered_username)
         .fetch_one(&mut transaction)
         .await);
 
@@ -31,7 +37,7 @@ pub(crate) async fn register(body: web::Json<RegisterJsonRequest>, db_pool: web:
         }).await;
     }
 
-    let captcha_success = bail!(captcha::verify_captcha(&body.h_captcha_response.to_owned()).await);
+    let captcha_success = true/*bail!(captcha::verify_captcha(&body.h_captcha_response.to_owned()).await)*/;
 
     if !captcha_success {
         return HttpResponse::UnprocessableEntity().json(RegisterJsonResponse {
@@ -41,17 +47,34 @@ pub(crate) async fn register(body: web::Json<RegisterJsonRequest>, db_pool: web:
         }).await;
     }
 
-    let mut user = bail!(User::new(
-        body.username.to_owned(), body.email.to_owned(), body.password.to_owned()
+    let mut user: User = bail!(User::new(
+        username.to_owned(), body.email.to_owned(), body.password.to_owned()
     ));
     bail!(user.save(db_pool.get_ref()).await);
 
     bail!(transaction.commit().await);
+
+    bail!(user.send_template(&templates::VERIFY_EMAIL, Some([
+            ("username".to_owned(), user.username.to_owned()),
+            ("link".to_owned(), "bruuh4".to_owned())
+    ].iter().cloned().collect())).await);
+
+    info!("New user registered: {} (id {})", user.username, user.id);
+
     HttpResponse::Ok().json(RegisterJsonResponse {
         success: true,
         id: Some(user.id),
         errors: None
     }).await
+}
+
+fn validate_username(username: &String) -> String {
+    let regex = Regex::new("[^\\u0000-\\u007F]+").unwrap();
+
+    match regex.find(username) {
+        Some(matched_text) => matched_text.as_str().to_owned(),
+        None => "".to_owned()
+    }.replace(" ", "-")
 }
 
 #[derive(Deserialize)]

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -1,0 +1,16 @@
+use crate::templates::plain::Template;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+pub(crate) mod plain;
+
+lazy_static! {
+    pub(crate) static ref VERIFY_EMAIL: Template = parse_template("email/user/verify_email.txt".to_owned());
+}
+
+fn parse_template(template_path: String) -> Template {
+    match plain::parse(template_path) {
+        Ok(template) => template,
+        Err(err) => panic!("Failed to parse template: {}", err)
+    }
+}

--- a/src/templates/plain.rs
+++ b/src/templates/plain.rs
@@ -1,0 +1,51 @@
+use anyhow::{anyhow, Context, Result};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+pub(crate) type Template = (String, HashMap<String, String>);
+pub(crate) type TemplateContext = HashMap<String, String>;
+
+pub(crate) fn parse(mut template_path: String) -> Result<Template> {
+    let mut template_dir = Path::new("templates/");
+    let path = template_dir.join(&template_path);
+
+    let content = fs::read_to_string(path)?;
+    let mut skip_lines = 0;
+
+    let mut tags = HashMap::new();
+    tags.insert("template_name".to_owned(), template_path.clone());
+
+    for (index, line) in content.lines().enumerate() {
+        if line == "---" {
+            skip_lines = index + 2;
+            break;
+        }
+
+        let mut splitter = line.splitn(2, ": ");
+        let key = splitter.next().unwrap_or_default();
+        let value = splitter.next().unwrap_or_default();
+
+        if key.is_empty() || value.is_empty() {
+            return Err(anyhow!("Template `{}` meta data contains empty values", template_path));
+        }
+
+        tags.insert(key.to_owned(), value.to_owned());
+    }
+
+    let vec: Vec<&str> = content.lines().skip(skip_lines).collect();
+
+    Ok((vec.join("\n"), tags))
+}
+
+pub(crate) fn render(template_content: String, context_option: Option<TemplateContext>) -> String {
+    let mut result = template_content;
+
+    if let Some(context) = context_option {
+        for (key, value) in context {
+            result = result.replace(format!("{{{{{}}}}}", key).as_str(), value.as_str());
+        }
+    }
+
+    result
+}

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,8 +1,11 @@
 use anyhow::{anyhow, Context, Result};
-use crate::PgPoolConnection;
+use crate::templates::plain::{render, Template, TemplateContext};
+use crate::{CONFIG, crypto, mail, PgPoolConnection};
+use lettre::Message;
 use sqlx::pool::PoolConnection;
 use sqlx::postgres::PgQueryAs;
 use sqlx::{Connection, Executor, FromRow, PgConnection, PgPool, Transaction};
+use std::borrow::Borrow;
 
 #[derive(FromRow)]
 pub(crate) struct User {
@@ -10,25 +13,32 @@ pub(crate) struct User {
     pub(crate) username: String, // Ascii-only
     pub(crate) email: String,
     pub(crate) password: String,
-    salt: String,
+    pub(crate) salt: String,
+    pub(crate) email_verified: bool
 }
 
 impl User {
     /// Creates a new user object. The user is not yet saved to the database.
     pub(crate) fn new(username: String, email: String, raw_password: String) -> Result<Self> {
-        let (password, salt) = crate::crypto::hash_password(raw_password).context("Failed to hash password.")?;
+        let (password, salt) = crypto::hash_password(raw_password).context("Failed to hash password.")?;
 
         Ok(User {
             id: -1, // User has not yet been placed in the database.
             username,
             email,
             password,
-            salt
+            salt,
+            email_verified: false
         })
     }
 
-    /// Saves this user to the database and populates the user id
+    /// Saves this user to the database and populates the user id.
+    /// If a error gets returned, the user was not inserted into the database.
     pub(crate) async fn save(&mut self, database_pool: &PgPool) -> Result<()> {
+        if self.id > 0 {
+            return Err(anyhow!("User id ({}) already saved to database", self.id));
+        }
+
         let connection = database_pool.acquire().await.context("Unable to acquire connection.")?;
         let mut transaction: Transaction<PgPoolConnection> = connection.begin().await.context("Unable to start transaction.")?;
 
@@ -54,5 +64,31 @@ impl User {
         transaction.commit().await?;
 
         Ok(())
+    }
+
+    pub(crate) async fn send_mail(&self, subject: &String, body: String) -> Result<()> {
+        let address: &str = CONFIG.smtp.email_address.borrow();
+
+        let message = Message::builder()
+            .from(format!("GitArena <{}>", address).parse().context("Unable to parse `from` email.")?)
+            .to(format!("{} <{}>", self.username, self.email).parse().context("Unable to parse `to` email.")?)
+            .subject(subject)
+            .body(body)
+            .context("Unable to build email.")?;
+
+        Ok(mail::send_mail(message).await?)
+    }
+
+    pub(crate) async fn send_template(&self, template: &Template, context: Option<TemplateContext>) -> Result<()> {
+        let (body, tags) = template;
+        let email_body = render(body.to_string(), context);
+
+        if !tags.contains_key("subject") {
+            return Err(anyhow!("Template {} does not contain subject tag.", tags.get("template_name").unwrap()));
+        }
+
+        let subject = tags.get("subject").unwrap();
+
+        Ok(self.send_mail(subject, email_body).await?)
     }
 }

--- a/templates/email/user/verify_email.txt
+++ b/templates/email/user/verify_email.txt
@@ -1,0 +1,13 @@
+subject: Verify your e-mail address
+---
+
+Hi {{username}}
+
+Thanks for signing up to GitArena. Please verify your e-mail address by clicking the link:
+{{link}}
+
+If you did not create the account, please ignore this e-mail. The account will be automatically
+deactivated if no e-mail has been verified within 24 hours.
+
+--
+GitArena | https://gitarena.com


### PR DESCRIPTION
Currently uses an alpha version of `lettre` for async support with `tokio`. Need to upgrade this asap when the full version is out.